### PR TITLE
Modify Jiang & Conrath similarity formula

### DIFF
--- a/build/lib.linux-x86_64-2.7/sematch/semantic/similarity.py
+++ b/build/lib.linux-x86_64-2.7/sematch/semantic/similarity.py
@@ -165,7 +165,7 @@ class ConceptSimilarity:
         lcs_ic = 2.0 * lcs_ic
         if c1_ic == 0.0 or c2_ic == 0.0:
             return 0.0
-        return 1.0 / 1 + (c1_ic + c2_ic - lcs_ic)
+        return 1.0 / (1 + c1_ic + c2_ic - lcs_ic)
 
     def wpath(self, c1, c2, k=0.8):
         lcs = self.least_common_subsumer(c1, c2)


### PR DESCRIPTION
I believe that following this change to `jcn` the formula will be comparable to the [DiShIn implementation](https://github.com/lasigeBioTM/DiShIn/blob/d6e5f41c3a8b61d7851f645bfae78a3104f70e1d/ssmpy/ssm.py#L561-L591).

Is there a reference implementation or publication that these similarity formulas should be based off of? One challenge is that I'm seeing different formulas in the literature for these metrics.