### PR TITLE
fix: import `Hashable` from `collections.abc`

### DIFF
--- a/sematch/classify.py
+++ b/sematch/classify.py
@@ -43,7 +43,7 @@ def prepare_lexicon(process=True, dim=250, save=False):
 from gensim.models import Word2Vec
 from numpy import array, dot
 from gensim import matutils
-import collections
+import collections.abc
 import functools
 
 
@@ -53,7 +53,7 @@ class memoized(object):
         self.cache = {}
 
     def __call__(self, *args):
-        if not isinstance(args, collections.Hashable):
+        if not isinstance(args, collections.abc.Hashable):
             # uncacheable. a list, for instance.
             # better to not cache than blow up.
             return self.func(*args)

--- a/sematch/utility.py
+++ b/sematch/utility.py
@@ -57,7 +57,7 @@ class FileIO:
         return data
 
 
-import collections
+import collections.abc
 import functools
 
 class memoized(object):
@@ -69,7 +69,7 @@ class memoized(object):
       self.func = func
       self.cache = {}
    def __call__(self, *args):
-      if not isinstance(args, collections.Hashable):
+      if not isinstance(args, collections.abc.Hashable):
          # uncacheable. a list, for instance.
          # better to not cache than blow up.
          return self.func(*args)


### PR DESCRIPTION
In Python 3.10+, `collections.Hashable` is completely removed (instead of being deprecated, like in 3.9), this PR changes that import to `collections.abc.Hashable` for compatibility.

See: https://stackoverflow.com/a/70195883